### PR TITLE
Enable uploading to s3

### DIFF
--- a/charge.rb
+++ b/charge.rb
@@ -23,6 +23,8 @@ Charge::Config.set_buckets SOURCE_BUCKET, LIVE_BUCKET
 Charge::Config.set_url_root S3_URL_ROOT
 Charge::Config.set_base_prefix BASE_PREFIX
 
+Charge::Config.stub_uploads unless ENV['ENABLE_S3_UPLOADS'] == true
+
 helpers do
    def get_parent_dir directory
       paths = directory.split('/')

--- a/charge.rb
+++ b/charge.rb
@@ -23,7 +23,7 @@ Charge::Config.set_buckets SOURCE_BUCKET, LIVE_BUCKET
 Charge::Config.set_url_root S3_URL_ROOT
 Charge::Config.set_base_prefix BASE_PREFIX
 
-Charge::Config.stub_uploads unless ENV['ENABLE_S3_UPLOADS'] == true
+Charge::Config.stub_uploads unless ENV['ENABLE_S3_UPLOADS'] == 'true'
 
 helpers do
    def get_parent_dir directory

--- a/lib/charge/actions/editor.rb
+++ b/lib/charge/actions/editor.rb
@@ -62,13 +62,12 @@ module Charge
          def upload_converted_file
             live_bucket = Config.live_bucket
 
-            stream_warning "Uploading to the live ifixit-assets bucket is a no-op!"
-            stream_msg "Displaying image instead!"
+            stream_msg "Displaying new live image:"
             size_k = @new_live_image.length / 1024 
             stream_msg "New Live File size: #{size_k}K"
             stream_msg "<img src=\"#{Helpers::ImageUrl.image_to_url 'image', @new_live_image}\">"
 
-            #@s3.upload(@new_live_image, live_bucket, @upload_spec.key)
+            @s3.upload(@new_live_image, live_bucket, @edit_spec.key)
          end
 
          def record_metadata

--- a/lib/charge/actions/uploader.rb
+++ b/lib/charge/actions/uploader.rb
@@ -97,25 +97,23 @@ module Charge
          def upload_to_source
             source_bucket = Config.source_bucket
 
-            stream_warning "Skipping source upload for testing"
-            stream_msg "Displaying image instead!"
+            stream_msg "displaying uploaded image"
             size_k = @new_source_file.length / 1024 
             stream_msg "File Source File Size: #{size_k}K"
             stream_msg "<img src=\"#{Helpers::ImageUrl.image_to_url 'image', @new_source_file}\">"
 
-            #@s3.upload(new_source_file, source_bucket, @upload_spec.key)
+            @s3.upload(@new_source_file, source_bucket, @upload_spec.key)
          end
 
          def upload_to_live
             live_bucket = Config.live_bucket
 
-            stream_warning "Uploading to the live ifixit-assets bucket is a no-op!"
-            stream_msg "displaying image instead!"
+            stream_msg "displaying new live image"
             size_k = @new_live_file.length / 1024 
             stream_msg "new live file size: #{size_k}k"
             stream_msg "<img src=\"#{Helpers::ImageUrl.image_to_url 'image', @new_live_file}\">"
 
-            #@s3.upload(new_live_file, live_bucket, @upload_spec.key)
+            @s3.upload(@new_live_file, live_bucket, @upload_spec.key)
          end
 
          def record_metadata

--- a/lib/charge/factories/upload_spec_factory.rb
+++ b/lib/charge/factories/upload_spec_factory.rb
@@ -6,6 +6,7 @@ module Charge
          class << self
             def from_form_params params
                directory = params[:splat].first
+               directory = ensure_ends_in_slash(directory)
                file = params[:file]
                filename = file[:filename]
                upload_spec = Values::UploadSpec.new(
@@ -22,6 +23,12 @@ module Charge
                   upload_spec.set_convert_to_jpeg
                end
                return upload_spec
+            end
+
+            def ensure_ends_in_slash directory
+               directory_without_slashes = directory.sub(/\/+$/, '')
+               directory_ending_in_slash = directory_without_slashes + '/'
+               return directory_ending_in_slash
             end
          end
       end

--- a/lib/charge/services/s3.rb
+++ b/lib/charge/services/s3.rb
@@ -51,14 +51,12 @@ module Charge
          def upload file, bucket, key
             puts "Uploading '#{key}' to bucket: '#{bucket}'"
             s3_put_params = {
-               body: file,
+               body: IO.read(file),
                bucket: bucket,
                key: key,
                acl: 'public-read',
                cache_control: "public, max-age=#{SECONDS_IN_A_YEAR}",
             }
-            puts "put_object request params:"
-            puts s3_put_params.to_h
 
             resp = client.put_object(s3_put_params)
 

--- a/lib/charge/services/s3.rb
+++ b/lib/charge/services/s3.rb
@@ -51,7 +51,7 @@ module Charge
          def upload file, bucket, key
             puts "Uploading '#{key}' to bucket: '#{bucket}'"
             s3_put_params = {
-               body: file.path,
+               body: file,
                bucket: bucket,
                key: key,
                acl: 'public-read',

--- a/lib/charge/services/s3.rb
+++ b/lib/charge/services/s3.rb
@@ -5,6 +5,8 @@ require 'tempfile'
 module Charge
    module Services
       class S3
+         SECONDS_IN_A_YEAR = 60 * 60 * 24 * 365;
+
          # Used to filter large objects list
          IGNORED_LARGE_OBJECT_EXTS = [
             'pdf',
@@ -48,17 +50,25 @@ module Charge
 
          def upload file, bucket, key
             puts "Uploading '#{key}' to bucket: '#{bucket}'"
-            puts "upload is still a noop!"
-# Current implementation:
-#$secondsInYear = 60 * 60 * 24 * 365;                                    
-#$s3sync = 'aws s3 sync';                                                
-#$params = "{$dry} --acl public-read " .                                 
-# "--cache-control 'public, max-age={$secondsInYear}' --follow-symlinks";
+            s3_put_params = {
+               body: file.path,
+               bucket: bucket,
+               key: key,
+               acl: 'public-read',
+               cache_control: "public, max-age=#{SECONDS_IN_A_YEAR}",
+            }
+            puts "put_object request params:"
+            puts s3_put_params.to_h
+
+            resp = client.put_object(s3_put_params)
+
+            puts "put_object response params:"
+            puts resp.to_h
          end
 
          def exists_in_s3? bucket, key
             s3 = Aws::S3::Resource.new(region: @region)
-            s3bucket = s3.bucket(bucket) 
+            s3bucket = s3.bucket(bucket)
             return s3bucket.object(key).exists?
          end
 

--- a/lib/charge/values/s3reference.rb
+++ b/lib/charge/values/s3reference.rb
@@ -29,6 +29,10 @@ module Charge
             return root_url + @key
          end
 
+         def uncached_url
+            return url + '?' + Time.new.to_i.to_s
+         end
+
          def root_url
            return Config.url_root + bucket + '/'
          end

--- a/views/edit.erb
+++ b/views/edit.erb
@@ -36,4 +36,4 @@
 <hr>
 <h2>Current Source Image:</h2>
 <hr>
-<img src="<%= @asset.source.url %>" />
+<img src="<%= @asset.source.uncached_url %>" />

--- a/views/live_metadata.erb
+++ b/views/live_metadata.erb
@@ -1,7 +1,7 @@
 <p> Live:
 <ul>
    <li>
-      Link: <a href="<%= @asset.live.url %>"><%= @asset.live.url %></a>
+      Link: <a href="<%= @asset.live.uncached_url %>"><%= @asset.live.url %></a>
    </li>
 <% if @asset.live.exists_in_s3? %>
    <li>Size: <%= @asset.live.size / 1024 %>K</li>

--- a/views/original_metadata.erb
+++ b/views/original_metadata.erb
@@ -1,7 +1,7 @@
 <p> Original:
 <ul>
    <li>
-      Link: <a href="<%= @asset.source.url %>"><%= @asset.source.url %></a>
+      Link: <a href="<%= @asset.source.uncached_url %>"><%= @asset.source.url %></a>
    </li>
 <% if @asset.source.exists_in_s3? %>
    <li>Size: <%= @asset.source.size / 1024 %>K</li>

--- a/views/view.erb
+++ b/views/view.erb
@@ -12,11 +12,11 @@
 <hr>
 <h2>Current Live Image:</h2>
 <hr>
-<img src="<%= @asset.live.url %>" />
+<img src="<%= @asset.live.uncached_url %>" />
 <hr>
 <h2>Current Source Image:</h2>
 <hr>
-<img src="<%= @asset.source.url %>" />
+<img src="<%= @asset.source.uncached_url %>" />
 
 <script>
    console.log("Did something go wrong?");


### PR DESCRIPTION
Do the thing! Let's implement and (safely) allow enabling live S3 uploads! :tada: 

The `acl` and `cache-control` params for the `put-object` call are a little bit hardcoded for now, but these settings are exactly what we want for now. 

For safety, i've made stubbing out the S3 service the default. If we want to really do thing, we've got to do it intentionally.

Closes: https://github.com/iFixit/charge/issues/4

CC @danielbeardsley 