### PR TITLE
Cache bust dev

### DIFF
--- a/charge.rb
+++ b/charge.rb
@@ -23,6 +23,9 @@ Charge::Config.set_buckets SOURCE_BUCKET, LIVE_BUCKET
 Charge::Config.set_url_root S3_URL_ROOT
 Charge::Config.set_base_prefix BASE_PREFIX
 
+hosts_to_cache_bust = ENV['HOSTS_TO_CACHE_BUST'].split(',') || []
+Charge::Config.set_hosts_to_cache_bust hosts_to_cache_bust
+
 Charge::Config.stub_uploads unless ENV['ENABLE_S3_UPLOADS'] == 'true'
 
 helpers do

--- a/lib/charge/actions/editor.rb
+++ b/lib/charge/actions/editor.rb
@@ -5,6 +5,8 @@ require 'services/image_converter'
 require 'helpers/streaming_output'
 require 'helpers/imageurl'
 
+require 'services/cache_buster'
+
 require 'tempfile'
 
 module Charge
@@ -68,6 +70,8 @@ module Charge
             stream_msg "<img src=\"#{Helpers::ImageUrl.image_to_url 'image', @new_live_image}\">"
 
             @s3.upload(@new_live_image, live_bucket, @edit_spec.key)
+
+            Services::CacheBuster.bust_cache_on_hosts @edit_spec.key
          end
 
          def record_metadata

--- a/lib/charge/charge.rb
+++ b/lib/charge/charge.rb
@@ -23,6 +23,8 @@ module Charge
          attr_reader :url_root
          attr_reader :base_prefix
 
+         attr_reader :hosts_to_cache_bust
+
          def set_buckets source_bucket, live_bucket
             @source_bucket = source_bucket
             @live_bucket = live_bucket
@@ -38,6 +40,10 @@ module Charge
 
          def stub_uploads
             @s3service = Services::S3Stubbed
+         end
+
+         def set_hosts_to_cache_bust hosts_list
+            @hosts_to_cache_bust = hosts_list
          end
       end
    end

--- a/lib/charge/services/cache_buster.rb
+++ b/lib/charge/services/cache_buster.rb
@@ -1,3 +1,6 @@
+require 'net/http'
+require 'uri'
+
 module Charge
    module Services
       class CacheBuster
@@ -11,6 +14,15 @@ module Charge
 
             def bust_cache_on_host host, key
                puts "Cache bust '#{key}' on host '#{host}'"
+               delete_uri = URI.parse("https://#{host}/#{key}")
+               puts "Sending DELETE to: #{delete_uri}"
+               begin
+                  response = Net::HTTP.get_response(delete_uri)
+                  puts "DELETE response code: #{reponse.code}"
+               rescue StandardError => e
+                  puts "Delete failed for URI: #{delete_uri}"
+                  puts "ERROR: #{e.inspect}"
+               end
             end
          end
       end

--- a/lib/charge/services/cache_buster.rb
+++ b/lib/charge/services/cache_buster.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'uri'
+require 'openssl'
 
 module Charge
    module Services
@@ -16,9 +17,17 @@ module Charge
                puts "Cache bust '#{key}' on host '#{host}'"
                delete_uri = URI.parse("https://#{host}/#{key}")
                puts "Sending DELETE to: #{delete_uri}"
+               request = Net::HTTP::Delete.new(delete_uri)
+               req_options = {
+                  use_ssl: delete_uri.scheme == "https",
+                  verify_mode: OpenSSL::SSL::VERIFY_NONE,
+               }
                begin
-                  response = Net::HTTP.get_response(delete_uri)
-                  puts "DELETE response code: #{reponse.code}"
+                  response = Net::HTTP.start(delete_uri.hostname,
+                        delete_uri.port, req_options) do |http|
+                     http.request(request)
+                  end
+                  puts "DELETE response code: #{response.code}"
                rescue StandardError => e
                   puts "Delete failed for URI: #{delete_uri}"
                   puts "ERROR: #{e.inspect}"

--- a/lib/charge/services/cache_buster.rb
+++ b/lib/charge/services/cache_buster.rb
@@ -1,0 +1,18 @@
+module Charge
+   module Services
+      class CacheBuster
+         class << self
+            def bust_cache_on_hosts key
+               return if Config.hosts_to_cache_bust.nil?
+               Config.hosts_to_cache_bust.each do |host|
+                  self.bust_cache_on_host host, key
+               end
+            end
+
+            def bust_cache_on_host host, key
+               puts "Cache bust '#{key}' on host '#{host}'"
+            end
+         end
+      end
+   end
+end


### PR DESCRIPTION
When we change a file in S3, we want to ping back to dev and CI to clear their local caches of those files.

We've implemented a DELETE responder in Code that does exactly this. We just need to `curl -k -X DELETE https://<dev-server>/<key>`.

The ruby code to accomplish this curl (without installing another Gem) was figured out by utilizing this tool: https://jhawthorn.github.io/curl-to-ruby/

I've manually QA'd this, and even reloaded Apache on the CI machine to pick up the recent static sucking changes.

qa_req 0

CC @danielbeardsley 

Closes:  https://github.com/iFixit/charge/issues/7