### PR TITLE
Move existence check to after prepare

### DIFF
--- a/lib/charge/actions/uploader.rb
+++ b/lib/charge/actions/uploader.rb
@@ -18,7 +18,6 @@ module Charge
          def upload
             stream_msg "Uploading file '#{@upload_spec.key}'..."
             check_filesize
-            return if already_exists_in_s3?
 
             @uploaded_file = @upload_spec.file[:tempfile]
             @new_source_file = prepare_source_file
@@ -26,6 +25,7 @@ module Charge
 
             apply_conversion
 
+            return if already_exists_in_s3?
             upload_to_source
             upload_to_live
 


### PR DESCRIPTION
If we're converting an uploaded file to JPEG, we change the upload
destination by munging the file extension. However, we were checking the
destination _before_ changing the extension. This is a bug.

Move the S3 existence check to _after_ `prepare_source_file`, which
munges the file extension. This ensures that we're checking the correct
intended upload destination.

CC @davidrans 

Closes: #13 
