### PR TITLE
Cache bust on upload if overwriting

### DIFF
--- a/lib/charge/actions/uploader.rb
+++ b/lib/charge/actions/uploader.rb
@@ -114,6 +114,10 @@ module Charge
             stream_msg "<img src=\"#{Helpers::ImageUrl.image_to_url 'image', @new_live_file}\">"
 
             @s3.upload(@new_live_file, live_bucket, @upload_spec.key)
+
+            if @upload_spec.allow_overwrite
+               Services::CacheBuster.bust_cache_on_hosts @upload_spec.key
+            end
          end
 
          def record_metadata


### PR DESCRIPTION
Shaun found a neat bug! If you upload, and overwrite with charge, it's
not cache busting.

CC @danielbeardsley @hackalot805