### PR TITLE
Glean content types on upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /opt/charge
 
 WORKDIR /opt/charge
 
-RUN dnf -y install ruby rubygem-bundler ImageMagick pngquant \
+RUN dnf -y install ruby rubygem-bundler ImageMagick pngquant file \
    && bundle install --without test development
 
 ENV CHARGE_PORT=8881

--- a/lib/charge/services/s3.rb
+++ b/lib/charge/services/s3.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk-s3'
 
 require 'tempfile'
+require 'shellwords'
 
 module Charge
    module Services
@@ -117,7 +118,7 @@ module Charge
          end
 
          def glean_content_type file
-            content_type_with_charset = `file -bi #{file.path}`
+            content_type_with_charset = `file -bi #{file.path.shellescape}`
             content_type = content_type_with_charset.chomp.split(';').first
             return content_type || ""
          end

--- a/lib/charge/services/s3.rb
+++ b/lib/charge/services/s3.rb
@@ -50,12 +50,14 @@ module Charge
 
          def upload file, bucket, key
             puts "Uploading '#{key}' to bucket: '#{bucket}'"
+            content_type = glean_content_type file
             s3_put_params = {
                body: IO.read(file),
                bucket: bucket,
                key: key,
                acl: 'public-read',
                cache_control: "public, max-age=#{SECONDS_IN_A_YEAR}",
+               content_type: content_type,
             }
 
             resp = client.put_object(s3_put_params)
@@ -112,6 +114,12 @@ module Charge
                   raise StopIteration unless fetch_next
                end
             end.lazy
+         end
+
+         def glean_content_type file
+            content_type_with_charset = `file -bi #{file.path}`
+            content_type = content_type_with_charset.chomp.split(';').first
+            return content_type || ""
          end
       end
 


### PR DESCRIPTION
We want to be setting the content type in S3 on upload. If the file
doesn't have an extension, it seems like S3 doesn't even bother to try
gleaning the file format.

qa_req 0

CC @danielbeardsley @andyg0808 