### PR TITLE
Add an edit link on the upload page

### DIFF
--- a/lib/charge/actions/uploader.rb
+++ b/lib/charge/actions/uploader.rb
@@ -128,7 +128,8 @@ module Charge
 
          def provide_view_link
             key = @upload_spec.key
-            stream_msg "View new file at <a href=\"/view/#{key}\">#{key}</a>"
+            stream_msg %Q(View new file at <a href="/view/#{key}">#{key}</a>)
+            stream_msg %Q(<a href="/edit/#{key}">Edit the new image</a>)
          end
       end
    end


### PR DESCRIPTION
Very frequently, I find myself uploading an image and immediately editing it. This provides a convenient edit link directly on the new image, rather than having to click to the image view to see the link.

In the process, I also switched the string quotes on the view link to avoid the need to escape the double-quotes.

This is currently untested.