### PR TITLE
Default HOSTS_TO_CACHE_BUST to empty string instead of nil

### DIFF
--- a/charge.rb
+++ b/charge.rb
@@ -23,7 +23,7 @@ Charge::Config.set_buckets SOURCE_BUCKET, LIVE_BUCKET
 Charge::Config.set_url_root S3_URL_ROOT
 Charge::Config.set_base_prefix BASE_PREFIX
 
-hosts_to_cache_bust = ENV['HOSTS_TO_CACHE_BUST'].split(',') || []
+hosts_to_cache_bust = (ENV['HOSTS_TO_CACHE_BUST'] || '').split(',')
 Charge::Config.set_hosts_to_cache_bust hosts_to_cache_bust
 
 Charge::Config.stub_uploads unless ENV['ENABLE_S3_UPLOADS'] == 'true'

--- a/lib/charge/services/cache_buster.rb
+++ b/lib/charge/services/cache_buster.rb
@@ -7,7 +7,6 @@ module Charge
       class CacheBuster
          class << self
             def bust_cache_on_hosts key
-               return if Config.hosts_to_cache_bust.nil?
                Config.hosts_to_cache_bust.each do |host|
                   self.bust_cache_on_host host, key
                end


### PR DESCRIPTION
Hey friendos, I was trying to set this up and was running into an issue when the HOSTS_TO_CACHE_BUST variable was unset. I thought I'd make a PR.

This defaults the HOSTS_TO_CACHE_BUST env variable variable to empty
string instead of nil, because calling .split on nil results in an error.

This also removes the nil check in services/cache_buster.rb because
charge.rb sets the config to always be an array.