### PR TITLE
Make Charge compatible with Fedora 32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:32
 MAINTAINER "Daryl Metzler"
 
 RUN dnf -y install ruby rubygem-bundler ImageMagick pngquant file

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,4 +99,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
Lets upgrade charge to Fedora 32. While we're here, lets not assume that Fedora 32 is equivalent to `fedora:latest` in the Dockerfile. This should save us the same headache down the line.

Practically, this just means updating the Gemfile.lock to say it was made with a compatible version of bundler.

```
bundle update --bundler
```
This did the trick. We could update all the rest of the dependencies while we're here, but they all appear to be semantic version bumps. Lets keep it simple.

Ref: https://github.com/iFixit/server-templates/issues/2583

CC @danielbeardsley @iFixit/devops 