### PR TITLE
Upgrade Charge to Fedora 39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:39
 MAINTAINER "Daryl Metzler"
 
 RUN dnf -y install ruby rubygem-bundler ImageMagick pngquant file


### PR DESCRIPTION
This will get us some newer additional image types for `file`.

qa_req 0

CC @ianrohde 