### PR TITLE
Add some gems to support upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'aws-sdk-s3', '~> 1'
+gem 'webrick'
+gem 'rexml', '3.2.6'
 
 gem "mini_magick"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rexml (3.2.6)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -84,6 +85,7 @@ GEM
       tilt (~> 2.0)
     thor (1.0.1)
     tilt (2.0.11)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -94,9 +96,11 @@ DEPENDENCIES
   guard
   guard-rspec
   mini_magick
+  rexml (= 3.2.6)
   rspec
   rspec-core
   sinatra
+  webrick
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Sinatra now needs a rack compatible webserver, and the AWS SDK needs an XML parser implementation. Install those. Found deploying https://github.com/iFixit/charge/pull/33

qa_req 0 (the new version is running on cominor time now)

CC @ianrohde 