### PR TITLE
Address conversion failures, SVG uploads

### DIFF
--- a/lib/charge/actions/editor.rb
+++ b/lib/charge/actions/editor.rb
@@ -54,10 +54,21 @@ module Charge
                         @source_image, @new_live_image, @edit_spec)
 
             stream_msg "Applying image conversion..."
-            Services::ImageConverter.convert_image @conversion
-            stream_msg "Image conversion complete!"
+            begin
+               Services::ImageConverter.convert_image @conversion
+            rescue Charge::ConversionFailed => e
+               stream_warning e.message
+               raise
+            end
 
-            new_size_k = @new_live_image.length / 1024 
+            if @new_live_image.length == 0
+               stream_warning "Conversion produced an empty file; aborting edit."
+               raise Charge::ConversionFailed,
+                  "Conversion produced an empty file for #{@edit_spec.key}"
+            end
+
+            stream_msg "Image conversion complete!"
+            new_size_k = @new_live_image.length / 1024
             stream_msg "Live file size after conversion: #{new_size_k}K"
          end
 

--- a/lib/charge/actions/uploader.rb
+++ b/lib/charge/actions/uploader.rb
@@ -92,10 +92,21 @@ module Charge
             @conversion = Factories::ConversionSpecFactory.default_conversion(
                   @new_source_file, @new_live_file)
             stream_msg "Applying default image conversion..."
-            Services::ImageConverter.convert_image @conversion
-            stream_msg "Default image conversion complete!"
+            begin
+               Services::ImageConverter.convert_image @conversion
+            rescue Charge::ConversionFailed => e
+               stream_warning e.message
+               raise
+            end
 
-            new_size_k = @new_live_file.length / 1024 
+            if @new_live_file.length == 0
+               stream_warning "Conversion produced an empty file; aborting upload."
+               raise Charge::ConversionFailed,
+                  "Conversion produced an empty file for #{@upload_spec.key}"
+            end
+
+            stream_msg "Default image conversion complete!"
+            new_size_k = @new_live_file.length / 1024
             stream_msg "Live file size after default conversion: #{new_size_k}K"
          end
 

--- a/lib/charge/actions/uploader.rb
+++ b/lib/charge/actions/uploader.rb
@@ -76,11 +76,16 @@ module Charge
          end
 
          def apply_conversion
-            if @upload_spec.do_conversion
+            if @upload_spec.do_conversion && !svg?
                convert_image
-            else 
+            else
+               stream_msg "Skipping default image conversion for SVG." if svg?
                @new_live_file = @new_source_file
             end
+         end
+
+         def svg?
+            File.extname(@upload_spec.filename).downcase == '.svg'
          end
 
          def convert_image

--- a/lib/charge/exceptions.rb
+++ b/lib/charge/exceptions.rb
@@ -7,4 +7,7 @@ module Charge
 
    class EditFailure < StandardError
    end
+
+   class ConversionFailed < StandardError
+   end
 end

--- a/lib/charge/services/image_converter.rb
+++ b/lib/charge/services/image_converter.rb
@@ -17,7 +17,7 @@ module Charge
                   imagick = MiniMagick::Image.open input_path
                   resize_opt = self.build_resize_option conversion_spec
                   imagick.resize resize_opt unless resize_opt.nil?
-                  imagick.quality conversion_spec.quality 
+                  imagick.quality conversion_spec.quality
                   imagick.write output_path
                   puts "Image conversion successfull"
                   if imagick.type == "PNG"
@@ -25,9 +25,10 @@ module Charge
                      self.optimize_png conversion_spec.output_file
                   end
                   puts "Conversion process complete!"
-               rescue
-                  puts "Image conversion failed!"
-                  return false
+               rescue => e
+                  puts "Image conversion failed: #{e.message}"
+                  raise Charge::ConversionFailed,
+                     "Image conversion failed: #{e.message}"
                end
                return true
             end


### PR DESCRIPTION
A few fixes. 

We were previously throwing away conversion failures during upload and edit.
We can expose the failures back to users during upload and edit.
Do not even bother trying the default conversion (even if selected) against SVGs.

Running live on dev. SVG uploads work (even if you leave the default conversion box checked)
qa_req 0

Closes: https://github.com/iFixit/charge/issues/53

CC @hcutrone 